### PR TITLE
Address Issues with 511.org Rate Limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ Be sure to have the **CircuitPython 10.x** UF2 firmware installed on the Matrix 
 
 ## Instructions
 
-1. Connect the board to the LED display as shown [here](https://learn.adafruit.com/adafruit-matrixportal-s3/prep-the-matrixportal)
-2. Follow the instructions [here](https://learn.adafruit.com/adafruit-matrixportal-s3/install-circuitpython) to install CircuitPython on the Portal S3, using the USB-C data cable
-3. Download the Adafruit 10.x CircuitPython bundle [here](https://circuitpython.org/libraries)
-4. Download the font to be used from [here](https://opensource.apple.com/source/X11fonts/X11fonts-14/font-misc-misc/font-misc-misc-1.1.2/5x7.bdf.auto.html) backup in bundle [here](https://www.cl.cam.ac.uk/~mgk25/ucs-fonts.html)
-5. Go to the 511.org website and request an API token using the form [here](https://511.org/open-data/token), this shouldn't take long
+1. Connect the board to the LED display as shown [here](https://learn.adafruit.com/adafruit-matrixportal-s3/prep-the-matrixportal).
+2. Follow the instructions [here](https://learn.adafruit.com/adafruit-matrixportal-s3/install-circuitpython) to install CircuitPython on the Portal S3, using the USB-C data cable.
+3. Download the Adafruit 10.x CircuitPython bundle [here](https://circuitpython.org/libraries).
+4. Download the font to be used from [here](https://opensource.apple.com/source/X11fonts/X11fonts-14/font-misc-misc/font-misc-misc-1.1.2/5x7.bdf.auto.html) backup in bundle [here](https://www.cl.cam.ac.uk/~mgk25/ucs-fonts.html).
+5. Go to the 511.org website and request an API token using the form [here](https://511.org/open-data/token), and this shouldn't take long.
 6. Open the `settings.toml` file and input the following values (the rest can be left as a working example for San Francisco's Powell station predictions for now):
     - `CIRCUITPY_WIFI_SSID` the 2.4GHz network to which the board will connect
     - `CIRCUITPY_WIFI_PASSWORD` the network password
@@ -33,8 +33,8 @@ Be sure to have the **CircuitPython 10.x** UF2 firmware installed on the Matrix 
     - `adafuit_connection_manager.mpy` (copy the file)
     - `adafruit_datetime.mpy` (copy the file)
     - `adafruit_requests.mpy` (copy the file)
-9. Copy all the python files from this repo as well as the toml file onto the board's root directory and approval overwrite when asked
-10. Safely eject the board from the computer and move the cable from the computer to the USB-C power plug (or use the power USB-C cable instead)
+9. Copy all the python files from this repo as well as the toml file onto the board's root directory and approval overwrite when asked.
+10. Safely eject the board from the computer and move the cable from the computer to the USB-C power plug (or use the power USB-C cable instead).
 
 ### The final result should look like this:
 
@@ -47,14 +47,15 @@ The example could also be changed to support more transit lines per LED display 
 ## Troubleshooting Steps
 
 - It's sometimes the case the board will not go into bootloader mode. Follow the instructions [here](https://learn.adafruit.com/adafruit-matrixportal-s3/factory-reset) to factory reset the unit and try the 'double tap' trick again to flash CircuitPython onto the board.
-- Transit examples do not run 24/7 so if no results are displayed this might be run too late at night, and it's best to come back to it the next day
+- Transit examples do not run 24/7 so if no results are displayed this might be run too late at night, and it's best to come back to it the next day.
 - The `config.py` file has a `DEBUG_MODE` to enable logging and the console output instead of the sign itself when set to `True`.
 
 ## Next Steps
 
-- The values in the `settings.toml` file can be changed based on the stop, direction(s) (OB and/or IB), and routes that are of interest now that the board and sign are up and running using comma-delimited separation where appropriate
-- Other displays can be used and appearances can be customized in the `transit_predictions_app_io.py` file for the display
-- Other APIs or regions can be used in the `transit_predictions_app_io.py` for sources
+- The values in the `settings.toml` file can be changed based on the stop, direction(s) (OB and/or IB), and routes that are of interest now that the board and sign are up and running using comma-delimited separation where appropriate.
+- The rate limit can be changed in the `settings.toml` file as well per API in case a plan allows a higher frequency, with the default set to avoid this limit if not provided.
+- Other displays can be used and appearances can be customized in the `transit_predictions_app_io.py` file for the display.
+- Other APIs or regions can be used in the `transit_predictions_app_io.py` for sources.
 
 ## References
 

--- a/app511/api_511.py
+++ b/app511/api_511.py
@@ -40,39 +40,62 @@ class _JsonHandler(TransitDataHandler):
         :return: the predictions that are available if any
         """
 
-        predictions = {}
-        now = _JsonHandler._extract_now(data)
+        if not data or not isinstance(data, dict):
+            return {}
 
         # The list of upcoming visits to the stop in the predictions.
-        visits: list = data['ServiceDelivery']['StopMonitoringDelivery']['MonitoredStopVisit']
+        service_delivery: dict = data.get("ServiceDelivery", {})
+        stop_monitoring_delivery: dict = service_delivery.get("StopMonitoringDelivery", {})
+        visits: list = stop_monitoring_delivery.get("MonitoredStopVisit", [])
+
+        if not visits:
+            return {}
 
         route_codes: list[str] = keys[0]
         directions: list[str] = keys[1]
+        now = _JsonHandler._extract_now(data)
+        predictions = {}
 
         # Iterate over all the upcoming visits and gather predictions.
         for visit in visits:
-            trip: dict = visit['MonitoredVehicleJourney']
-            route_code: str = trip['LineRef']
+            trip: dict = visit.get('MonitoredVehicleJourney', {})
+            route_code: str = trip.get('LineRef')
+            direction: str = trip.get('DirectionRef')
 
-            # The route code is not of interest in the trip or not in the correct direction(s).
-            if route_code not in route_codes or trip['DirectionRef'] not in directions:
+            # The route code or direction does not exist.
+            if not route_code or not direction:
                 continue
 
-            # The predictions don't have the route in it yet, add it.
-            if route_code not in predictions:
-                title: str = trip['PublishedLineName']
-                route = Route(route_code, title)
-                predictions[route_code] = route
+            # The route code is not of interest in the trip or not in the correct direction(s).
+            if route_code not in route_codes or direction not in directions:
+                continue
 
             # The predicted time of the visit.
-            prediction_info: dict = trip['MonitoredCall']
-            arrival_time: str = prediction_info['ExpectedArrivalTime']
+            prediction_info: dict = trip.get('MonitoredCall', {})
+            arrival_time: str = prediction_info.get('ExpectedArrivalTime')
+
+            if not arrival_time:
+                continue
+
             # CircuitPython only parses DateTime from iso formats without the 'T' and 'Z' in them.
             arrival_time = arrival_time.replace('T', ' ').replace('Z', '')
-            prediction = datetime.fromisoformat(arrival_time)
+
+            try:
+                prediction = datetime.fromisoformat(arrival_time)
+            except ValueError:
+                continue
+
+            if prediction <= now:
+                continue
 
             # The minutes until the trip's arrival.
             minutes = int((prediction - now).seconds / 60)
+
+            # The predictions don't have the route in it yet, add it.
+            if route_code not in predictions:
+                title: str = trip.get('PublishedLineName', route_code)
+                route = Route(route_code, title)
+                predictions[route_code] = route
 
             # Add the minutes to the set of predictions.
             predictions[route_code].add_prediction(minutes)
@@ -90,50 +113,119 @@ class _JsonHandler(TransitDataHandler):
         :return: the next arrival time or 0 if there are no predictions
         """
 
-        now = _JsonHandler._extract_now(data)
+        if not data or not isinstance(data, dict):
+            return None
 
         # The list of upcoming visits to the stop in the predictions.
-        visits: list = data['ServiceDelivery']['StopMonitoringDelivery']['MonitoredStopVisit']
+        service_delivery: dict = data.get("ServiceDelivery", {})
+        stop_monitoring_delivery: dict = service_delivery.get("StopMonitoringDelivery", {})
+        visits: list = stop_monitoring_delivery.get("MonitoredStopVisit", [])
+
+        if not visits:
+            return None
 
         route_codes: list[str] = keys[0]
         directions: list[str] = keys[1]
+        now = _JsonHandler._extract_now(data)
+        soonest_seconds = None
 
         # Iterate over all the upcoming visits and find the soonest arrival of desired route codes.
         for visit in visits:
-            trip: dict = visit['MonitoredVehicleJourney']
-            route_code: str = trip['LineRef']
+            trip: dict = visit.get('MonitoredVehicleJourney', {})
+            route_code: str = trip.get('LineRef')
+            direction: str = trip.get('DirectionRef')
 
-            # The route code is not of interest in the trip or it not in the correct direction(s).
-            if route_code not in route_codes or trip['DirectionRef'] not in directions:
+            # The route code or direction does not exist.
+            if not route_code or not direction:
+                continue
+
+            # The route code is not of interest in the trip or not in the correct direction(s).
+            if route_code not in route_codes or direction not in directions:
                 continue
 
             # The predicted time of the visit.
-            prediction_info: dict = trip['MonitoredCall']
-            arrival_time: str = prediction_info['ExpectedArrivalTime']
+            prediction_info: dict = trip.get('MonitoredCall', {})
+            arrival_time: str = prediction_info.get('ExpectedArrivalTime')
+
+            if not arrival_time:
+                continue
+
             # CircuitPython only parses DateTime from iso formats without the 'T' and 'Z' in them.
             arrival_time = arrival_time.replace('T', ' ').replace('Z', '')
-            prediction = datetime.fromisoformat(arrival_time)
 
-            # Return how many seconds until the next arrival.
-            return int((prediction - now).seconds)
+            try:
+                prediction = datetime.fromisoformat(arrival_time)
+            except ValueError:
+                continue
 
-        # There are no predictions of interest, return None.
-        return None
+            if prediction <= now:
+                continue
+
+            seconds_diff = int((prediction - now).seconds)
+
+            # Keep the smallest wait time value found across all valid routes
+            if soonest_seconds is None or seconds_diff < soonest_seconds:
+                soonest_seconds = seconds_diff
+
+        return soonest_seconds
 
     @staticmethod
     def _extract_now(data: dict) -> datetime:
+        """
+        Takes all the prediction JSON and collects the service's current date and time.
+
+        :param data: the data to parse
+        :return: the datetime
+        """
+
+        if not data or not isinstance(data, dict):
+            return datetime.now()
+
         # The time the predictions data was sent.
         # This is used because some predictions come back with a 'created' unix time stamp
         # of 0, so they are inaccurate to use for temporal subtraction so a unified baseline
         # of 'now' is used to get around this flaw in the API response.
-        data_time: str = data['ServiceDelivery']['StopMonitoringDelivery']['ResponseTimestamp']
+        service_delivery: dict = data.get("ServiceDelivery", {})
+        stop_monitoring_delivery: dict = service_delivery.get("StopMonitoringDelivery", {})
+        data_time: str = stop_monitoring_delivery.get('ResponseTimestamp')
+
+        if not data_time:
+            return datetime.now()
+
         # CircuitPython only parses DateTime from iso formats without the 'T' and 'Z' in them.
         data_time = data_time.replace('T', ' ').replace('Z', '')
 
-        return datetime.fromisoformat(data_time)
+        try:
+            api_now = datetime.fromisoformat(data_time)
+
+            # Update the device real time clock to the one from 511.org.
+            # This keeps datetime.now() from crashing and gives a
+            # non-arbitrary time to fall back on.
+            import rtc
+
+            try:
+                rtc.RTC().datetime = time_tuple = (
+                        api_now.year, api_now.month, api_now.day,
+                        api_now.hour, api_now.minute, api_now.second,
+                        0, -1, -1
+                )
+            except Exception:
+                pass
+
+            return api_now
+
+        except ValueError:
+            return datetime.now()
 
     @staticmethod
     def parse_data(data: str) -> dict:
+        """
+        Loads the JSON data into a dictionary.
+
+        :param data: the JSON data to load
+        :return: the data dictionary
+        """
+
         return loads(data)
 
 
@@ -192,4 +284,4 @@ class TransitAPI511(TransitAPI):
         parameters = f'agency={agency}&stopCode={stop_code}'
         endpoint = self._get_command_url(command, parameters)
 
-        return self._requests.get(endpoint)
+        return self._requests.get(endpoint, timeout=10)

--- a/app511/config_511.py
+++ b/app511/config_511.py
@@ -39,9 +39,9 @@ class TransitConfig511:
 
         return TransitConfig511(
             getenv('511_API_KEY'),
-            getenv('511_API_LIMIT', '60'),      # rate limit (default every 60 seconds as per documentation minimum)
-            getenv('511_TRANSIT_AGENCY'),       # agency
-            getenv('511_TRANSIT_DIRECTIONS'),   # directions
-            getenv('511_TRANSIT_ROUTE_CODES'),  # route_codes
-            getenv('511_TRANSIT_STOP_CODE')     # stop_code
+            getenv('511_API_LIMIT', '60'),             # rate limit (default every 60 seconds as per documentation minimum)
+            getenv('511_TRANSIT_AGENCY', 'SF'),        # agency
+            getenv('511_TRANSIT_DIRECTIONS', 'OB'),    # directions
+            getenv('511_TRANSIT_ROUTE_CODES', 'K,N'),  # route_codes
+            getenv('511_TRANSIT_STOP_CODE', '16995')   # stop_code
         )

--- a/app511/config_511.py
+++ b/app511/config_511.py
@@ -10,7 +10,7 @@ class TransitConfig511:
     Holds the configuration for fetching predictions.
     """
 
-    def __init__(self, api_key: str, agency: str, directions: str, route_codes: str, stop_code: str):
+    def __init__(self, api_key: str, rate: str, agency: str, directions: str, route_codes: str, stop_code: str):
         """
         Construct a new 'TransitConfig511' object using the provided configuration.
 
@@ -24,6 +24,7 @@ class TransitConfig511:
         self.api_key = api_key
         self.directions =  directions.split(',')
         self.route_codes = route_codes.split(',')
+        self.rate = int(rate)
         self.stop_code = stop_code
 
     @staticmethod
@@ -36,8 +37,9 @@ class TransitConfig511:
 
         return TransitConfig511(
             getenv('511_API_KEY'),
-            getenv('511_TRANSIT_AGENCY'),  # agency
-            getenv('511_TRANSIT_DIRECTIONS'),  # directions
+            getenv('511_API_LIMIT', '60'),      # rate limit (default every 60 seconds as per documentation minimum)
+            getenv('511_TRANSIT_AGENCY'),       # agency
+            getenv('511_TRANSIT_DIRECTIONS'),   # directions
             getenv('511_TRANSIT_ROUTE_CODES'),  # route_codes
-            getenv('511_TRANSIT_STOP_CODE')  # stop_code
+            getenv('511_TRANSIT_STOP_CODE')     # stop_code
         )

--- a/app511/config_511.py
+++ b/app511/config_511.py
@@ -14,6 +14,8 @@ class TransitConfig511:
         """
         Construct a new 'TransitConfig511' object using the provided configuration.
 
+        :param api_key: the key with which to fetch predictions
+        :param rate: the rate (in seconds) of interval for which to fetch predictions
         :param agency: the transit agency
         :param directions: the directions (could be one direction, the other, or both)
         :param route_codes: the routes of interest

--- a/app511/predictions_app_511.py
+++ b/app511/predictions_app_511.py
@@ -23,7 +23,7 @@ RESPONSE_FORMAT = 'json'
 
 ERROR_REFRESH_SEC = 30
 MAX_REFRESH_SEC = 60
-MIN_REFRESH_SEC = 10
+MIN_REFRESH_SEC = 20
 
 
 class TransitPredictionsApp511(TransitPredictionsApp):
@@ -162,4 +162,7 @@ class TransitPredictionsApp511(TransitPredictionsApp):
 
         self._display.show(self._get_predictions())
 
-        return self._get_refresh_interval()
+        if DEBUG_MODE:
+            return self._get_refresh_interval()
+        else:
+            return self._api_config.rate

--- a/app511/predictions_app_511.py
+++ b/app511/predictions_app_511.py
@@ -84,12 +84,7 @@ class TransitPredictionsApp511(TransitPredictionsApp):
                     prediction_text.extend(route_text)
 
         if DEBUG_MODE:
-            if prediction_text:
-                for text in prediction_text:
-                    print(text)
-
-                print('')
-            else:
+            if not prediction_text:
                 print('No predictions available\n')
 
         return prediction_text
@@ -131,6 +126,9 @@ class TransitPredictionsApp511(TransitPredictionsApp):
         if TransitAPI511.check_for_success(self._status_code):
             data = decompress(response.content, 31)[3:].decode('utf-8')
             self._data = self._source.get_data_handler().parse_data(data)
+            
+            # Free up all this memory or the next poll's allocation will fail on some devices.
+            del data
         elif DEBUG_MODE:
             print(f'Status code: {self._status_code}\n')
             print(f'Reason: {self._reason}\n')
@@ -139,7 +137,6 @@ class TransitPredictionsApp511(TransitPredictionsApp):
 
         # Free up all this memory or the next poll's allocation will fail on some devices.
         del response
-        del data
         collect()
 
     def update(self) -> int:

--- a/app511/predictions_app_511.py
+++ b/app511/predictions_app_511.py
@@ -13,6 +13,7 @@ from app511.api_511 import TransitAPI511
 from app511.config_511 import TransitConfig511
 from config import DEBUG_MODE
 from display.display import DisplayConfigration
+from network import Wifi
 from transit.predictions_app import TransitPredictionsApp
 
 # SOURCE
@@ -78,6 +79,8 @@ class TransitPredictionsApp511(TransitPredictionsApp):
             for route_code in self._api_config.route_codes:
                 if route_code in predictions:
                     route = predictions[route_code]
+                    route.predictions.sort()
+
                     route_text = self._formatter.format(
                         route,
                         self._display_config.maximum_predictions,
@@ -120,31 +123,59 @@ class TransitPredictionsApp511(TransitPredictionsApp):
         Polls for prediction data and stores it at class level.
         """
 
-        # Wipe the existing data and fetch new data.
+        # Reset the existing data.
+        data = None
+        response = None
         self._data = None
-        response = self._source.get_predictions((self._api_config.agency, self._api_config.stop_code))
-        self._status_code = response.status_code
-        self._reason = response.reason.decode('utf-8')
+        self._status_code = "Connection Failed"
+        self._reason = "Timeout/No Response"
 
-        if TransitAPI511.check_for_success(self._status_code):
-            data = decompress(response.content, 31)[3:].decode('utf-8')
-            self._data = self._source.get_data_handler().parse_data(data)
-            self._consecutive_failures = 0
+        # Fetch new data
+        try:
+            Wifi.ensure_connected()
 
-            # Free up all this memory or the next poll's allocation will fail on some devices.
-            del data
-        else:
+            response = self._source.get_predictions((self._api_config.agency, self._api_config.stop_code))
+            self._status_code = response.status_code
+
+            if isinstance(response.reason, bytes):
+                self._reason = response.reason.decode('utf-8')
+            else:
+                self._reason = response.reason
+
+            if TransitAPI511.check_for_success(self._status_code):
+                data = decompress(response.content, 31)[3:].decode('utf-8')
+                self._data = self._source.get_data_handler().parse_data(data)
+                self._consecutive_failures = 0
+            else:
+                self._consecutive_failures += 1
+
+                if DEBUG_MODE:
+                    print(f'Status code: {self._status_code}\n')
+                    print(f'Reason: {self._reason}\n')
+
+        except Exception as e:
+            # Catch raw socket/network drop exceptions before an HTTP response is ever made.
             self._consecutive_failures += 1
+            self._status_code = "Network Error"
+            self._reason = str(e)
 
             if DEBUG_MODE:
-                print(f'Status code: {self._status_code}\n')
-                print(f'Reason: {self._reason}\n')
+                print(f'Socket exception caught during fetch: {e}\n')
 
-        response.close()
+        finally:
+            # Free up all this memory or the next poll's allocation will fail on some devices.
+            if response is not None:
+                try:
+                    response.close()
+                except Exception:
+                    pass
 
-        # Free up all this memory or the next poll's allocation will fail on some devices.
-        del response
-        collect()
+                del response
+
+            if data is not None:
+                del data
+
+            collect()
 
     def update(self) -> int:
         """
@@ -163,7 +194,7 @@ class TransitPredictionsApp511(TransitPredictionsApp):
             self._display.show(['Network Error', f'{self._status_code}', f'{self._reason}'])
 
             backoff_sec = (2 ** (self._consecutive_failures - 1)) * ERROR_REFRESH_SEC
-            actual_wait = min(MAX_BACKOFF, max_backoff)
+            actual_wait = min(backoff_sec, MAX_BACKOFF)
 
             if DEBUG_MODE:
                 print(f'Backing off due to failures ({self._consecutive_failures})\n')

--- a/app511/predictions_app_511.py
+++ b/app511/predictions_app_511.py
@@ -22,6 +22,7 @@ RESPONSE_FORMAT = 'json'
 # UPDATE
 
 ERROR_REFRESH_SEC = 30
+MAX_BACKOFF = 600
 MAX_REFRESH_SEC = 60
 MIN_REFRESH_SEC = 20
 
@@ -48,6 +49,8 @@ class TransitPredictionsApp511(TransitPredictionsApp):
 
         self._api_config = api_config
         self._display_config = display_config
+
+        self._consecutive_failures = 0
 
         self._display = display_config.get_display()
         self._display.show(['Predictions', 'for SF MUNI', 'using API', '511.org'])
@@ -126,12 +129,16 @@ class TransitPredictionsApp511(TransitPredictionsApp):
         if TransitAPI511.check_for_success(self._status_code):
             data = decompress(response.content, 31)[3:].decode('utf-8')
             self._data = self._source.get_data_handler().parse_data(data)
-            
+            self._consecutive_failures = 0
+
             # Free up all this memory or the next poll's allocation will fail on some devices.
             del data
-        elif DEBUG_MODE:
-            print(f'Status code: {self._status_code}\n')
-            print(f'Reason: {self._reason}\n')
+        else:
+            self._consecutive_failures += 1
+
+            if DEBUG_MODE:
+                print(f'Status code: {self._status_code}\n')
+                print(f'Reason: {self._reason}\n')
 
         response.close()
 
@@ -155,7 +162,13 @@ class TransitPredictionsApp511(TransitPredictionsApp):
         if not self._data:
             self._display.show(['Network Error', f'{self._status_code}', f'{self._reason}'])
 
-            return ERROR_REFRESH_SEC
+            backoff_sec = (2 ** (self._consecutive_failures - 1)) * ERROR_REFRESH_SEC
+            actual_wait = min(MAX_BACKOFF, max_backoff)
+
+            if DEBUG_MODE:
+                print(f'Backing off due to failures ({self._consecutive_failures})\n')
+
+            return actual_wait
 
         self._display.show(self._get_predictions())
 

--- a/code.py
+++ b/code.py
@@ -17,7 +17,7 @@ from display.configuration_matrix_64_x_32_fancy import ConfigurationMatrix64X32F
 from network import Wifi
 
 RESET_DELAY_SEC = 30
-RUN_DELAY_SEC = 0
+RUN_DELAY_SEC = 5
 
 try:
     # Sometimes while coding things can hang up so good to leave a gap of time to wait
@@ -49,6 +49,7 @@ except Exception as e:
     if DEBUG_MODE:
         print(f'Error:\n {str(e)}')
         print(f'Resetting microcontroller in {RESET_DELAY_SEC} seconds')
+
     # Comment out these if doing active development in case of failure to the program ends.
     sleep(RESET_DELAY_SEC)
     reset()

--- a/display/configuration_console.py
+++ b/display/configuration_console.py
@@ -4,18 +4,6 @@ TransitPredictionsApp. These are made to be swappable so the end user can
 configure the app to work with different prediction APIs and display
 devices. Replace with any self-written file that matches the API and
 hardware used if not the same as below.
-
-This configuration is set to use the 511.org API with a 64x32 RGB LED Matrix
-powered by a Matrix Portal S3 (ESP32-S3).
-
-It uses dependencies from adafruit-circuitpython-bundle-8.x found at:
-https://circuitpython.org/libraries
-
-and a font from Dr Markus Kuhn's website
-https://www.cl.cam.ac.uk/~mgk25/ucs-fonts.html
-
-specifically this font:
-https://opensource.apple.com/source/X11fonts/X11fonts-14/font-misc-misc/font-misc-misc-1.1.2/5x7.bdf.auto.html
 """
 
 # local

--- a/display/display.py
+++ b/display/display.py
@@ -106,6 +106,9 @@ class Sign(Display):
         for label in self._labels:
             label.text = ''
 
+        if not text:
+            return
+
         n = min(len(self._labels), len(text))
         i = 0
 

--- a/network.py
+++ b/network.py
@@ -19,14 +19,21 @@ class Wifi:
     Allows the device to connect to the internet using Wi-Fi
     """
 
-    @staticmethod
-    def connect(ssid: str, password: str):
+    # Cache credentials locally.
+    _ssid = None
+    _password = None
+
+    @classmethod
+    def connect(cls, ssid: str, password: str):
         """
         Connects to Wi-Fi using the provided credentials.
 
         :param ssid: the network for which to connect
         :param password: the network's password
         """
+
+        cls._ssid = ssid
+        cls._password = password
 
         if DEBUG_MODE:
             print(f'Connecting to WiFi using SSID: {ssid}')
@@ -35,6 +42,18 @@ class Wifi:
 
         if DEBUG_MODE:
             print(f'Connected to WiFi at IP address: {wifi.radio.ipv4_address}\n')
+
+    @classmethod
+    def ensure_connected(cls):
+        """
+        Checks if the Wi-Fi connection is alive, and forces a reconnect if it dropped.
+        """
+
+        if not wifi.radio.connected and cls._ssid is not None:
+            if DEBUG_MODE:
+                print("Wi-Fi hardware link lost! Re-establishing connection...")
+
+            wifi.radio.connect(cls._ssid, cls._password)
 
     @staticmethod
     def get_session() -> Session:

--- a/transit/prediction_formatter.py
+++ b/transit/prediction_formatter.py
@@ -22,16 +22,15 @@ class TransitPredictionFormatter:
         :return: the formatted route text as a list of str
         """
 
-        prediction_count = len(route.predictions)
-        n = min(max_predictions, prediction_count)
+        formatted_list = []
 
-        for i in range(n):
-            route.predictions[i] = f'{route.predictions[i]}m'
+        for minutes in route.predictions[:max_predictions]:
+            if minutes == 0:
+                formatted_list.append("Now")
+            else:
+                formatted_list.append(f"{minutes}m")
 
-        if route.predictions[0] == '0m':
-            route.predictions[0] = 'Now'
-
-        route_predictions = ' '.join(route.predictions[:n])
+        route_predictions = ' '.join(formatted_list)
 
         if show_title:
             line_text = f'{route.route_code} {route.title}'

--- a/transit/route.py
+++ b/transit/route.py
@@ -18,7 +18,7 @@ class Route:
 
         self.route_code = route_code
         self.title = title
-        self.predictions: [int] = []
+        self.predictions: list[int] = []
 
     def add_prediction(self, minutes: int):
         """


### PR DESCRIPTION
511.org has a rate limit of 60 requests per 3600 seconds (about 1 per minute). Some 504 errors were shown that could to be the result of refreshing too often.

This adds the ability to customize the refresh rate and defaults to this minimum rate limit (if not provided) as way to address the issue.

There are ways to reach out to 511 to increase rate limits so the option to customize makes sense in the `setting.toml` file.

The original min/max/next arrival algorithm is still present and changed be used for debugging mode only.

Error handling has also been improved with safe fallbacks and backoff retries.